### PR TITLE
Bump eventrouter image to v0.2.0

### DIFF
--- a/pkg/templates/rancherd-22-addons.yaml
+++ b/pkg/templates/rancherd-22-addons.yaml
@@ -91,7 +91,7 @@ resources:
           controlNamespace: cattle-logging-system
           workloadOverrides:
             containers:
-            - image: rancher/harvester-eventrouter:v0.1.2
+            - image: rancher/harvester-eventrouter:v0.2.0
               name: event-tailer
               resources:
                 limits:


### PR DESCRIPTION
Task: https://github.com/harvester/harvester/issues/5947

Image  release:
https://github.com/harvester/eventrouter/releases/tag/v0.2.0
Hold this PR until the image is released.