### PR TITLE
generate templates from version_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Repo contains addon info under `/pkg/templates` 
 
-The templates can directly be used by harvester-installer
+The templates need to be generated for harvester-installer packaging as follows:
+`go run . -generateTemplates -path $path_to_installer_templates`
 
 For harvester upgrade path, the templates need to be rendered, and easiest way to do the same is to call
 

--- a/main.go
+++ b/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/harvester/addons/pkg/render"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 const (
@@ -13,7 +14,7 @@ const (
 )
 
 func main() {
-	var generateAddons bool
+	var generateAddons, generateTemplates bool
 	var path string
 	app := &cli.App{
 		Flags: []cli.Flag{
@@ -22,6 +23,12 @@ func main() {
 				Value:       false,
 				Usage:       "generate disabled addon yaml manifests",
 				Destination: &generateAddons,
+			},
+			&cli.BoolFlag{
+				Name:        "generateTemplates",
+				Value:       false,
+				Usage:       "generate template manifests",
+				Destination: &generateTemplates,
 			},
 			&cli.StringFlag{
 				Name:        "path",
@@ -32,16 +39,21 @@ func main() {
 		},
 
 		Action: func(ctx *cli.Context) error {
-			if !generateAddons {
-				return fmt.Errorf("generateAddons need to be specified")
+			if !generateAddons && !generateTemplates {
+				return fmt.Errorf("generateAddons or generateTemplates need to be specified")
 			}
 
 			if generateAddons {
-				if err := render.Addon(templateSource, path); err != nil {
+				if err := render.Addon(templateSource, path, "version_info"); err != nil {
 					return fmt.Errorf("error during rendering addons: %v", err)
 				}
 			}
 
+			if generateTemplates {
+				if err := render.Template(templateSource, path, "version_info"); err != nil {
+					return fmt.Errorf("error during rendering template: %v", err)
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/render/addon.go
+++ b/pkg/render/addon.go
@@ -1,10 +1,12 @@
 package render
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -12,21 +14,43 @@ import (
 )
 
 const (
-	relativeTemplatePath = "../templates"
-	defaultFileName      = "rancherd-22-addons.yaml"
+	relativeTemplatePath    = "../templates"
+	defaultFileName         = "rancherd-22-addons.yaml"
+	relativeVersionFilePath = "../../"
+	defaultVersionFile      = "version_info"
+	imageSuffix             = "IMAGE"
 )
 
 type AddonResources struct {
 	Resources []map[string]interface{} `json:"resources,omitempty"`
 }
 
-func Addon(templateSource, destPath string) error {
-	contents, err := os.ReadFile(filepath.Join(templateSource, defaultFileName))
+func Addon(templateSource, destPath, versionFilePath string) error {
+
+	tmpDir := os.TempDir()
+	tmpPath, err := os.MkdirTemp(tmpDir, "rendered")
+	if err != nil {
+		return fmt.Errorf("error creating temp addon-template file: %v", err)
+	}
+	defer os.RemoveAll(tmpPath)
+
+	err = Template(templateSource, tmpPath, versionFilePath)
+	if err != nil {
+		return fmt.Errorf("error generating temp file: %v", err)
+	}
+
+	// read temporary template file to generate rendered addons
+	contents, err := os.ReadFile(filepath.Join(tmpPath, defaultFileName))
 	if err != nil {
 		return fmt.Errorf("error reading template file %s: %v", defaultFileName, err)
 	}
 
-	renderedContent, err := renderTemplate(contents)
+	tmpl, err := template.New("").Parse(string(contents))
+	if err != nil {
+		return err
+	}
+
+	renderedContent, err := renderTemplate(tmpl, versionFilePath)
 	if err != nil {
 		return fmt.Errorf("error rendering template: %v", err)
 	}
@@ -59,7 +83,7 @@ func Addon(templateSource, destPath string) error {
 			return fmt.Errorf("error marshalling map to addon contents for addon %s: %v", name, err)
 		}
 		fileName := fmt.Sprintf("%s.yaml", name)
-		err = os.WriteFile(filepath.Join(destPath, fileName), addonContents, 0755)
+		err = os.WriteFile(filepath.Join(destPath, fileName), addonContents, 0644)
 		if err != nil {
 			return fmt.Errorf("error writing addon file %s: %v", fileName, err)
 		}
@@ -67,15 +91,74 @@ func Addon(templateSource, destPath string) error {
 	return nil
 }
 
-func renderTemplate(content []byte) ([]byte, error) {
-	result := bytes.NewBufferString("")
-	tmpl, err := template.New("").Parse(string(content))
+func renderTemplate(tmpl *template.Template, versionFilePath string) ([]byte, error) {
+	envMap, err := generate_version_info_map(versionFilePath)
 	if err != nil {
 		return nil, err
 	}
-	err = tmpl.Execute(result, nil)
+
+	result := bytes.NewBufferString("")
+	err = tmpl.Execute(result, envMap)
 	if err != nil {
 		return nil, err
 	}
 	return result.Bytes(), nil
+}
+
+// generate_version_info_map reads the version_info file in project root
+// and renders a raw template which can be used for subsequent processing
+func generate_version_info_map(versionFilePath string) (map[string]string, error) {
+	versionFile, err := os.Open(versionFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening version file: %v", err)
+	}
+	defer versionFile.Close()
+	versionScanner := bufio.NewScanner(versionFile)
+
+	var lines []string
+	for versionScanner.Scan() {
+		lines = append(lines, versionScanner.Text())
+	}
+
+	result := make(map[string]string, len(lines))
+	for _, v := range lines {
+		fields := strings.Split(v, "=")
+		if len(fields) == 2 { // need check to ignore hash=bang directive in version info file
+			if strings.Contains(fields[0], imageSuffix) {
+				// in case of image names we only need tag info and not full image name
+				images := strings.Split(fields[1], ":")
+				result[fields[0]] = strings.Trim(images[1], "\"")
+
+			} else {
+				// in case of a helm chart there the string will not be of format image:tag
+				// but will only contain chart version
+				// for example NVIDIA_DRIVER_RUNTIME_CHART_VERSION="0.1.1"
+				result[fields[0]] = fields[1]
+			}
+		}
+	}
+	return result, nil
+}
+
+func Template(templateSource, destPath, versionFilePath string) error {
+	contents, err := os.ReadFile(filepath.Join(templateSource, defaultFileName))
+	if err != nil {
+		return fmt.Errorf("error reading template file %s: %v", defaultFileName, err)
+	}
+
+	tmpl, err := template.New("").Delims("<<", ">>").Parse(string(contents))
+	if err != nil {
+		return err
+	}
+	renderedContent, err := renderTemplate(tmpl, versionFilePath)
+	if err != nil {
+		return fmt.Errorf("error rendering template: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(destPath, defaultFileName), renderedContent, 0644)
+	if err != nil {
+		return fmt.Errorf("error writing addon file %s: %v", defaultFileName, err)
+	}
+
+	return nil
 }

--- a/pkg/render/addon_test.go
+++ b/pkg/render/addon_test.go
@@ -1,9 +1,11 @@
 package render
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Addon(t *testing.T) {
@@ -12,6 +14,24 @@ func Test_Addon(t *testing.T) {
 	tmpPath, err := os.MkdirTemp(tmpDir, "rendered")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpPath)
-	err = Addon(relativeTemplatePath, tmpPath)
+	err = Addon(relativeTemplatePath, tmpPath, filepath.Join(relativeVersionFilePath, defaultVersionFile))
+	assert.NoError(err)
+}
+
+func Test_generate_version_info_map(t *testing.T) {
+	assert := require.New(t)
+	result, err := generate_version_info_map(filepath.Join(relativeVersionFilePath, defaultVersionFile))
+	assert.NoError(err, "expected no error while reading version info map")
+	_, ok := result["VM_IMPORT_CONTROLLER_CHART_VERSION"]
+	assert.True(ok, "expected to find key VM_IMPORT_CONTROLLER_CHART_VERSION")
+}
+
+func Test_Template(t *testing.T) {
+	assert := require.New(t)
+	tmpDir := os.TempDir()
+	tmpPath, err := os.MkdirTemp(tmpDir, "template")
+	assert.NoError(err, "expected no error during tmp dir creation")
+	defer os.RemoveAll(tmpPath)
+	err = Template(relativeTemplatePath, tmpPath, filepath.Join(relativeVersionFilePath, defaultVersionFile))
 	assert.NoError(err)
 }

--- a/pkg/templates/rancherd-22-addons.yaml
+++ b/pkg/templates/rancherd-22-addons.yaml
@@ -6,7 +6,7 @@ resources:
       namespace: harvester-system
     spec:
       repo: http://harvester-cluster-repo.cattle-system.svc/charts
-      version: "0.3.0"
+      version: << .VM_IMPORT_CONTROLLER_CHART_VERSION >>
       chart: harvester-vm-import-controller
       {{- if and .Addons .Addons.harvester_vm_import_controller }}
       enabled: {{ .Addons.harvester_vm_import_controller.Enabled }}
@@ -15,7 +15,7 @@ resources:
       {{- end }}
       valuesContent: |
         image:
-          tag: v0.3.0
+          tag: << .VM_IMPORT_CONTROLLER_IMAGE >>
         fullnameOverride: harvester-vm-import-controller
   - apiVersion: harvesterhci.io/v1beta1
     kind: Addon
@@ -24,7 +24,7 @@ resources:
       namespace: harvester-system
     spec:
       repo: http://harvester-cluster-repo.cattle-system.svc/charts
-      version: "0.3.2"
+      version: << .PCIDEVICES_CONTROLLER_CHART_VERSION >>
       chart: harvester-pcidevices-controller
       {{- if and .Addons .Addons.harvester_pcidevices_controller }}
       enabled: {{ .Addons.harvester_pcidevices_controller.Enabled }}
@@ -33,7 +33,7 @@ resources:
       {{- end }}
       valuesContent: |
         image:
-          tag: v0.3.2
+          tag: << .PCIDEVICES_CONTROLLER_IMAGE >>
         fullnameOverride: harvester-pcidevices-controller
   - apiVersion: harvesterhci.io/v1beta1
     kind: Addon
@@ -203,7 +203,7 @@ resources:
       addon.harvesterhci.io/experimental: "true"
     spec:
       repo: http://harvester-cluster-repo.cattle-system.svc/charts
-      version: "0.3.0"
+      version: << .HARVESTER_SEEDER_CHART_VERSION >>
       chart: harvester-seeder
       {{- if and .Addons .Addons.harvester_seeder}}
       enabled: {{ .Addons.harvester_seeder.Enabled }}
@@ -212,7 +212,7 @@ resources:
       {{- end }}
       valuesContent: |
         image:
-          tag: v0.3.0
+          tag: << .HARVESTER_SEEDER_IMAGE >>
         fullnameOverride: harvester-seeder
   - apiVersion: harvesterhci.io/v1beta1
     kind: Addon
@@ -221,7 +221,7 @@ resources:
       namespace: harvester-system
     spec:
       repo: http://harvester-cluster-repo.cattle-system.svc/charts
-      version: "0.1.1"
+      version: << .NVIDIA_DRIVER_RUNTIME_CHART_VERSION >>
       chart: nvidia-driver-runtime
       {{- if and .Addons .Addons.nvidia_driver_toolkit}}
       enabled: {{ .Addons.nvidia_driver_toolkit.Enabled }}


### PR DESCRIPTION
PR introduces the following:
* uses the version_info file as source of truth to generate a template file
* uses generated template file to generate individual addon manifests

This ensures users only ever need to update the version_info file to ensure templates and addon manifests are generated from single source of truth.