### PR TITLE
Bump nvidia-driver-toolkit v1.5-20250331

### DIFF
--- a/pkg/templates/rancherd-22-addons.yaml
+++ b/pkg/templates/rancherd-22-addons.yaml
@@ -230,7 +230,7 @@ resources:
       {{- end }}
       valuesContent: |
         image:
-          tag: v1.5-20250324
+          tag: v1.5-20250331
           repo: rancher/harvester-nvidia-driver-toolkit
         driverLocation:  "HTTPENDPOINT/NVIDIA-Linux-x86_64-vgpu-kvm.run" 
         fullnameOverride: nvidia-driver-runtime


### PR DESCRIPTION
**Problem:**
The nvidia driver toolkit needs to update.
  
**Solution:**
Bump nvidia driver toolkit image as related baseos [rancher/harvester-os:v1.5-20250331](https://github.com/harvester/os2/releases/tag/v1.5-20250331).
  
**Related Issue:**
  
**Test plan:**