### PR TITLE
Disable rancher metrics as it is only enabled when mcm is enabled

### DIFF
--- a/pkg/templates/rancherd-22-addons.yaml
+++ b/pkg/templates/rancherd-22-addons.yaml
@@ -115,6 +115,8 @@ resources:
       enabled: false
       {{- end }}
       valuesContent: |
+        rancherMonitoring:
+          enabled: false
         alertmanager:
           enabled: true
           config:


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

`rancher-monitoring` stack complains `rancher` `TargetDown`

<img width="2680" height="570" alt="image" src="https://github.com/user-attachments/assets/772efbae-4c4e-4508-a7f1-816b03288407" />

After debugging with Rancher, we noticed that the `/metrics` on Rancher is only enabled when `mcm` is enabled.

https://github.com/rancher/rancher/blob/main/pkg/multiclustermanager/routes.go#L127

But the `embedded Rancher` on Harvester has below config, the `mcm` is disabled.

```
helm  -n cattle-system get values rancher
USER-SUPPLIED VALUES:
agentTLSMode: system-store
antiAffinity: required
bootstrapPassword: admin
features: multi-cluster-management=false,multi-cluster-management-agent=false,managed-system-upgrade-controller=false
global:
  cattle:
    psp:
      enabled: false
hostPort: 0
ingress:
  enabled: false
noDefaultAdmin: false
rancherImage: rancher/rancher
rancherImagePullPolicy: IfNotPresent
rancherImageTag: v2.12.0-alpha21
replicas: -3
systemDefaultRegistry: ""
tls: external
useBundledSystemChart: true
```

Prometheus can't scrap data from `rancher` service, and then complains.

```
# curl -k https://10.53.19.99:443/healthz
ok
# curl -k https://10.53.19.99:443/metrics
404 page not found

# curl -k http://10.53.19.99:80/metrics
<a href="https://10.53.19.99/metrics">Found</a>.
```

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Disable `rancher` `service monitor` to avoid fake alert.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/4958

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Enable rancher-monitoring addon, you will get the `TargetDown` alert upon `rancher` quickly on prometheus.

The object ` servicemonitor -n cattle-system rancher` appears.
```
$kubectl get servicemonitor -n cattle-system rancher -oyaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  annotations:
...
  creationTimestamp: "2025-07-23T14:25:26Z"
  generation: 1
  labels:
...
    heritage: Helm
    release: rancher-monitoring
  name: rancher
  namespace: cattle-system
...
spec:
  endpoints:
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    port: http
    tlsConfig:
      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
      insecureSkipVerify: true
      serverName: rancher
  jobLabel: rancher
  namespaceSelector:
    matchNames:
    - cattle-system
  selector:
    matchLabels:
      app: rancher
      chart: rancher-2.12.0-alpha21
      release: rancher
```


3. Change the addon spec to add below lines
```
    rancherMonitoring:
      enabled: false
```
```
kubectl get addons.harvesterhci.io -n cattle-monitoring-system rancher-monitoring -oyaml


  creationTimestamp: "2025-07-23T08:06:47Z"
  generation: 3
  name: rancher-monitoring
  namespace: cattle-monitoring-system
  resourceVersion: "418683"
  uid: 2ebbbca3-176b-4962-b4c4-7dbd44834d82
spec:
  chart: rancher-monitoring
  enabled: true
  repo: http://harvester-cluster-repo.cattle-system.svc/charts
  valuesContent: |
    rancherMonitoring:
      enabled: false
    alertmanager:
      enabled: true
      config:
```

4. After a while, check:

The object ` servicemonitor -n cattle-system rancher` disappears.
```
 # kubectl get servicemonitor -n cattle-system
No resources found in cattle-system namespace.
```

 The `TargetDown` alert is gone.




#### Additional documentation or context
