### PR TITLE
Fix grafana busybox patch

### DIFF
--- a/scripts/hack/patch-rancher-monitoring
+++ b/scripts/hack/patch-rancher-monitoring
@@ -30,7 +30,7 @@ patch_rancher_monitoring_chart()
 
   # replace grafana values busybox image version; yq can also work, but it strips all blank lines; use patch instead
   local valuesfile="./rancher-monitoring/charts/grafana/values.yaml"
-  local difffile="${pkg_monitoring_crd_path}/${monitoring_version}/patch-grafana-values.diff"
+  local difffile="${pkg_monitoring_path}/${monitoring_version}/patch-grafana-values.diff"
   echo "patch mirrored-library-busybox image version"
   echo "the current values.yaml has following mirrored-library-busybox image version"
   grep "mirrored-library-busybox" $valuesfile -2 || true


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
The grafana used busybox image was not effectively patched.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix the bug on patch.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8930

#### Test plan:
<!-- Describe the test plan by steps. -->

build log shows, with this PR, the grafana busybox is patched to `1.37.0`

```
before:


patch mirrored-library-busybox image version
the current values.yaml has following mirrored-library-busybox image version
  ##
  image:
    repository: rancher/mirrored-library-busybox
    tag: "1.31.1"
    sha: ""
diff file /107.1.0+up69.8.2-rancher.15/patch-grafana-values.diff is not found
the patched values.yaml has following mirrored-library-busybox image version
  ##
  image:
    repository: rancher/mirrored-library-busybox
    tag: "1.31.1"  // not patched
    sha: ""
patched file


after:

patch mirrored-library-busybox image version
the current values.yaml has following mirrored-library-busybox image version
  ##
  image:
    repository: rancher/mirrored-library-busybox
    tag: "1.31.1"
    sha: ""
patching file ./rancher-monitoring/charts/grafana/values.yaml
the patched values.yaml has following mirrored-library-busybox image version
  ##
  image:
    repository: rancher/mirrored-library-busybox
    tag: "1.37.0"  // as expected
    sha: ""
patched file
```



#### Additional documentation or context
