### PR TITLE
Enable metrics-server utilization for descheduler

### DIFF
--- a/pkg/render/addon_test.go
+++ b/pkg/render/addon_test.go
@@ -34,4 +34,8 @@ func Test_Template(t *testing.T) {
 	defer os.RemoveAll(tmpPath)
 	err = Template(relativeTemplatePath, tmpPath, filepath.Join(relativeVersionFilePath, defaultVersionFile))
 	assert.NoError(err)
+
+	rendered, err := os.ReadFile(filepath.Join(tmpPath, defaultFileName))
+	assert.NoError(err)
+	assert.Contains(string(rendered), "metricsUtilization:\n                  metricsServer: true")
 }

--- a/pkg/render/addon_test.go
+++ b/pkg/render/addon_test.go
@@ -37,5 +37,5 @@ func Test_Template(t *testing.T) {
 
 	rendered, err := os.ReadFile(filepath.Join(tmpPath, defaultFileName))
 	assert.NoError(err)
-	assert.Contains(string(rendered), "metricsUtilization:\n                  metricsServer: true")
+	assert.Regexp(`metricsUtilization:\s*metricsServer:\s*true`, string(rendered))
 }

--- a/pkg/templates/rancherd-22-addons.yaml
+++ b/pkg/templates/rancherd-22-addons.yaml
@@ -397,6 +397,8 @@ resources:
                         - "virt-launcher"
             - name: LowNodeUtilization
               args:
+                metricsUtilization:
+                  metricsServer: true
                 evictableNamespaces:
                   exclude:
                   - cattle-dashboards


### PR DESCRIPTION
#### Problem:
The descheduler LowNodeUtilization strategy currently scores nodes from pod requests. On KubeVirt clusters this misses actual VM runtime usage, so descheduling decisions can be ineffective for Harvester VM workloads.

#### Solution:
Enable metricsUtilization.metricsServer for the bundled descheduler LowNodeUtilization strategy so it reads node usage from metrics-server. Add a render assertion to keep the generated addon template from dropping the setting.

#### Related Issue(s):
Issue harvester/harvester#10547

#### Test plan:
- go test ./...
- go run . -generateTemplates -path /tmp/harvester-addons-rendered
- go run . -generateAddons -path /tmp/harvester-addons-rendered
- rg verified metricsUtilization.metricsServer in rendered rancherd-22-addons.yaml and descheduler.yaml