### PR TITLE
updates to ensure addons use -head images

### DIFF
--- a/version_info
+++ b/version_info
@@ -1,10 +1,10 @@
 #!/bin/bash
 VM_IMPORT_CONTROLLER_CHART_VERSION="1.8.1-dev.0"
-VM_IMPORT_CONTROLLER_IMAGE="rancher/harvester-vm-import-controller:v1.8.0"
+VM_IMPORT_CONTROLLER_IMAGE="rancher/harvester-vm-import-controller:v1.8-head"
 PCIDEVICES_CONTROLLER_CHART_VERSION="1.8.1-dev.0"
-PCIDEVICES_CONTROLLER_IMAGE="rancher/harvester-pcidevices:v1.8.0"
+PCIDEVICES_CONTROLLER_IMAGE="rancher/harvester-pcidevices:v1.8-head"
 HARVESTER_SEEDER_CHART_VERSION="1.8.1-dev.0"
-HARVESTER_SEEDER_IMAGE="rancher/harvester-seeder:v1.8.0"
+HARVESTER_SEEDER_IMAGE="rancher/harvester-seeder:v1.8-head"
 NVIDIA_DRIVER_RUNTIME_CHART_VERSION="1.8.1-dev.0"
 RANCHER_LOGGING_CHART_VERSION="108.0.2+up4.10.0-rancher.18"
 RANCHER_MONITORING_CHART_VERSION="108.0.2+up77.9.1-rancher.11"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR pins addon images to use `v1.8-head` tags

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
